### PR TITLE
Changes to allow the use of new Firebase Cloud Messaging systems

### DIFF
--- a/Pushraven/src/us/raudi/pushraven/Notification.java
+++ b/Pushraven/src/us/raudi/pushraven/Notification.java
@@ -24,10 +24,20 @@ public class Notification {
 
 	/**
 	 * Convert this object into JSON.
-	 *
-	 * @return JSON object adhering to the FCM format.
+	 * 
+	 * @return JSON object adhering to the old FCM format.
 	 */
 	public String toJSON() {
+		return toJSON(false);
+	}
+	
+	/**
+	 * Convert this object into JSON.
+	 *
+	 * @return JSON object adhering to the FCM format. It can be the new format, 
+	 * that requires the JSON to have a "message" field that includes the whole JSON
+	 */
+	public String toJSON(Boolean encapsulateRequestInMessage) {
 		JSONObject obj = new JSONObject(); // Parent object
 
 		// create and add every notification attribute into its own json objects
@@ -48,8 +58,14 @@ public class Notification {
 			// add targets to parent
 			obj.put("registration_ids", ids);
 		}
-
-		return obj.toString();
+		
+		String result = obj.toString();
+		if (encapsulateRequestInMessage){
+			result = new StringBuilder(result).insert(0, "{\"message\":").toString();
+			result = new StringBuilder(result).insert(result.length()-1, "}").toString();
+		}
+		
+		return result;
 	}
 
 	/**
@@ -307,6 +323,16 @@ public class Notification {
 	 */
 	public Notification title(String title) {
 		return addNotificationAttribute("title", title);
+	}
+	
+	/**
+	 * Indicates notification body text, appearing as "body" instead of "text".
+	 *
+	 * @param body Notification body
+	 * @return Itself as part of the Builder Pattern
+	 */
+	public Notification bodyAsBody(String body) {
+		return addNotificationAttribute("body", body);
 	}
 
 	/**

--- a/Pushraven/src/us/raudi/pushraven/Pushraven.java
+++ b/Pushraven/src/us/raudi/pushraven/Pushraven.java
@@ -7,13 +7,31 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 
 /**
- * Modular notificatiopn creation class.
+ * Modular notification creation class.
  *
- * @author Raudius
+ * @author Raudius, equintana
  */
 public class Pushraven {
-	private final static String API_URL = "https://fcm.googleapis.com/fcm/send";
+	
+	private final static String DEFAULT_API_URL = "https://fcm.googleapis.com/fcm/send";
+	private final static String DEFAULT_REQUEST_METHOD = "POST";
+	private final static String FIREBASE_SERVER_DEFAULT_AUTH_SYSTEM = "Authorization";
+	private final static String FIREBASE_SERVER_DEFAULT_TOKEN_SYSTEM = "key=";
+	private final static String FIREBASE_SERVER_DEFAULT_CONTENT_TYPE_KEY = "Content-Type";
+	private final static String FIREBASE_SERVER_DEFAULT_CONTENT_TYPE_VALUE = "application/json;charset=UTF-8";
+	private final static String FIREBASE_SERVER_DEFAULT_CODIFICATION = "UTF-8";
+	private final static Boolean FIREBASE_SERVER_DEFAULT_ENCAPSULATE_REQUEST_IN_MESSAGE = false;
+	
+	private static String API_URL;
+	private static String REQUEST_METHOD;
+	private static String FIREBASE_SERVER_AUTH_SYSTEM;
+	private static String FIREBASE_SERVER_TOKEN_SYSTEM;
 	private static String FIREBASE_SERVER_KEY;
+	private static String FIREBASE_SERVER_CONTENT_TYPE_KEY;
+	private static String FIREBASE_SERVER_CONTENT_TYPE_VALUE;
+	private static String FIREBASE_SERVER_CODIFICATION;
+	private static Boolean FIREBASE_SERVER_ENCAPSULATE_REQUEST_IN_MESSAGE;
+	
 	public static Notification notification;
 
 	// static initialization
@@ -22,6 +40,42 @@ public class Pushraven {
 	}
 
 	/**
+	 * Set the API URL
+	 *
+	 * @param apiUrl The URL of the API
+	 */
+	public static void setApiUrl(String apiUrl) {
+		API_URL = apiUrl;
+	}
+	
+	/**
+	 * Set the Request method
+	 *
+	 * @param requestMethod The Request method
+	 */
+	public static void setRequestMethod(String requestMethod) {
+		REQUEST_METHOD = requestMethod;
+	}
+	
+	/**
+	 * Set the API Server Auth System.
+	 *
+	 * @param key Firebase Server Auth System
+	 */
+	public static void setAuthSystem(String authSystem) {
+		FIREBASE_SERVER_AUTH_SYSTEM = authSystem;
+	}
+	
+	/**
+	 * Set the API Server Token System.
+	 *
+	 * @param key Firebase Server Token System (can be "key=" or "Bearer " or whatever)
+	 */
+	public static void setTokenSystem(String tokenSystem) {
+		FIREBASE_SERVER_TOKEN_SYSTEM = tokenSystem;
+	}
+	
+	/**
 	 * Set the API Server Key.
 	 *
 	 * @param key Firebase Server Key (NOT the Web API Key!!!)
@@ -29,7 +83,43 @@ public class Pushraven {
 	public static void setKey(String key) {
 		FIREBASE_SERVER_KEY = key;
 	}
-
+	
+	/**
+	 * Set the left part of the "Content type".
+	 *
+	 * @param contentTypeKey Content type key
+	 */
+	public static void setContentTypeKey(String contentTypeKey) {
+		FIREBASE_SERVER_CONTENT_TYPE_KEY = contentTypeKey;
+	}
+	
+	/**
+	 * Set the right part of the "Content type".
+	 *
+	 * @param contentTypeValue Content type value
+	 */
+	public static void setContentTypeValue(String contentTypeValue) {
+		FIREBASE_SERVER_CONTENT_TYPE_VALUE = contentTypeValue;
+	}
+	
+	/**
+	 * Set the codification for the BufferedWriter.
+	 *
+	 * @param codification BufferedWriter codification
+	 */
+	public static void setCodification(String codification) {
+		FIREBASE_SERVER_CODIFICATION = codification;
+	}
+	
+	/**
+	 * Set the condition to encapsulate the JSON object for the BufferedWriter inside a "message" field.
+	 *
+	 * @param encapsulateInMessage Boolean
+	 */
+	public static void setEncapsulateRequestInMessage(Boolean encapsulateRequestInMessage) {
+		FIREBASE_SERVER_ENCAPSULATE_REQUEST_IN_MESSAGE = encapsulateRequestInMessage;
+	}
+	
 	/**
 	 * Set new Notification object
 	 *
@@ -54,22 +144,32 @@ public class Pushraven {
 
 		HttpsURLConnection con = null;
 		try {
-			String url = API_URL;
-
+			if (API_URL == null){
+				API_URL = DEFAULT_API_URL;
+			}
+			String url = API_URL;			
 			URL obj = new URL(url);
 			con = (HttpsURLConnection) obj.openConnection();
 
-			con.setRequestMethod("POST");
-
-			// Set POST headers
-			con.setRequestProperty("Authorization", "key=" + FIREBASE_SERVER_KEY);
-			con.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+			if (REQUEST_METHOD == null){
+				REQUEST_METHOD = DEFAULT_REQUEST_METHOD;
+			}
+			con.setRequestMethod(REQUEST_METHOD);
+						
+			setRequestMethodHeaders(con);									
 
 			// Send POST body
 			con.setDoOutput(true);
 			DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"));
-			writer.write(n.toJSON());
+			if (FIREBASE_SERVER_CODIFICATION == null){
+				FIREBASE_SERVER_CODIFICATION = FIREBASE_SERVER_DEFAULT_CODIFICATION;
+			}
+			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(wr, FIREBASE_SERVER_CODIFICATION));
+			if (FIREBASE_SERVER_ENCAPSULATE_REQUEST_IN_MESSAGE == null){
+				FIREBASE_SERVER_ENCAPSULATE_REQUEST_IN_MESSAGE = FIREBASE_SERVER_DEFAULT_ENCAPSULATE_REQUEST_IN_MESSAGE;
+			}
+			String jsonToWrite = n.toJSON(FIREBASE_SERVER_ENCAPSULATE_REQUEST_IN_MESSAGE);			
+			writer.write(jsonToWrite);
 
 			// close output stream
 			writer.close();
@@ -84,7 +184,27 @@ public class Pushraven {
 
 		return new FcmResponse(con);
 	}
-
+	
+	/**
+	 * Set request method headers
+	 */
+	private static void setRequestMethodHeaders(HttpsURLConnection con){
+		if (FIREBASE_SERVER_AUTH_SYSTEM == null){
+			FIREBASE_SERVER_AUTH_SYSTEM = FIREBASE_SERVER_DEFAULT_AUTH_SYSTEM;
+		}
+		if (FIREBASE_SERVER_TOKEN_SYSTEM == null){
+			FIREBASE_SERVER_TOKEN_SYSTEM = FIREBASE_SERVER_DEFAULT_TOKEN_SYSTEM;
+		}		
+		if (FIREBASE_SERVER_CONTENT_TYPE_KEY == null){
+			FIREBASE_SERVER_CONTENT_TYPE_KEY = FIREBASE_SERVER_DEFAULT_CONTENT_TYPE_KEY;
+		}
+		if (FIREBASE_SERVER_CONTENT_TYPE_VALUE == null){
+			FIREBASE_SERVER_CONTENT_TYPE_VALUE = FIREBASE_SERVER_DEFAULT_CONTENT_TYPE_VALUE;
+		}		
+		con.setRequestProperty(FIREBASE_SERVER_AUTH_SYSTEM, FIREBASE_SERVER_TOKEN_SYSTEM + FIREBASE_SERVER_KEY);	
+		con.setRequestProperty(FIREBASE_SERVER_CONTENT_TYPE_KEY, FIREBASE_SERVER_CONTENT_TYPE_VALUE);			
+	}
+	
 	/**
 	 * Messages sent to targets.
 	 * This class interfaces with the FCM server by sending the Notification over HTTP-POST JSON.


### PR DESCRIPTION
Changes that allows Pushraven to keep working as usual, but add a new functionality: it is no longer limited to use the old authentication system for FCM (although it is still used by default, if not selected another one). The user can now configure parameters such as the URL of the FCM service or the authentication system. Pushraven can also generate the JSON for the notification inside the field 'message', as required by the new FCM system.

It also has been added a new function that allows the user to generate a 'body' field inside the 'notification' field directly, instead of automatically assigning the 'text'.