### PR TITLE
Correction to AndroidNotification tag method

### DIFF
--- a/Pushraven/src/us/raudi/pushraven/notifications/AndroidNotification.java
+++ b/Pushraven/src/us/raudi/pushraven/notifications/AndroidNotification.java
@@ -47,7 +47,7 @@ public class AndroidNotification extends Notification {
 	 * @return
 	 */
 	public AndroidNotification tag(String mytag) {
-		return (AndroidNotification) addAttribute("sound", mytag);
+		return (AndroidNotification) addAttribute("tag", mytag);
 	}
 	
 	/**


### PR DESCRIPTION
Original code uses "sound" instead of "tag" as the attribute key.